### PR TITLE
Add telegram verification to open notification form

### DIFF
--- a/way_to_home/static/src/components/profile/wayTab/wayItem/wayItem.js
+++ b/way_to_home/static/src/components/profile/wayTab/wayItem/wayItem.js
@@ -32,6 +32,7 @@ export default class WayItem extends Component{
         isWayFormOpen: true,
         isNotificationFormOpen: false,
         phone_number: undefined,
+        telegram_id: undefined
     };
 
     getData = () => {
@@ -69,6 +70,13 @@ export default class WayItem extends Component{
                 });
             })
             .catch(error => this.props.setMessage("Не вдалося завантажити номер телефону", 'error'));
+        axios.get('/api/v1/user/profile')
+            .then(response => {
+                this.setState({
+                    telegram_id: response.data.telegram_id,
+                });
+            })
+            .catch(error => this.props.setMessage("Не вдалося завантажити інформацію для телеграму", 'error'));
     };
 
     componentWillMount() {
@@ -76,8 +84,8 @@ export default class WayItem extends Component{
     };
 
     openNotificationForm = () => {
-        if (this.state.phone_number === ""){
-            this.props.setMessage("Спочатку введіть номер телефону", 'error')
+        if (!this.state.phone_number && !this.state.telegram_id){
+            this.props.setMessage("Спочатку введіть номер телефону або ввімкніть нотифікації через телеграм", 'error')
         } else {
             this.setState(state => ({
                 isNotificationFormOpen: !state.isNotificationFormOpen,


### PR DESCRIPTION
From now notification form can be opened if the user has telegram or phone number

## JIRA

* [Main JIRA ticket](https://ssu-jira.softserveinc.com/browse/PYTHON-)


## Code reviewers

- [ ] @meelros
- [ ] @BoroviyOrest
- [ ] @Kardan1123
- [x] @mizin4ik
- [ ] @dimigor
- [ ] @PetrushynskyiOleksii
- [ ] @Sasha1152

### Second Level Review

- [ ] @lhalam



## Summary of change

Add telegram verification to open notification form

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions